### PR TITLE
feat: 서블릿 사용자 정의 오류 페이지 추가

### DIFF
--- a/src/main/java/hello/exception/WebServerCustomizer.java
+++ b/src/main/java/hello/exception/WebServerCustomizer.java
@@ -1,0 +1,21 @@
+package hello.exception;
+
+import org.springframework.boot.web.server.ConfigurableWebServerFactory;
+import org.springframework.boot.web.server.ErrorPage;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebServerCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
+    @Override
+    public void customize(ConfigurableWebServerFactory factory) {
+
+        ErrorPage errorPage404 = new ErrorPage(HttpStatus.NOT_FOUND, "/error-page/404");
+        ErrorPage errorPage500 = new ErrorPage(HttpStatus.INTERNAL_SERVER_ERROR, "/error-page/500");
+        ErrorPage errorPageEx = new ErrorPage(RuntimeException.class, "/error-page/500");
+
+        factory.addErrorPages(errorPage404, errorPage500, errorPageEx);
+
+    }
+}

--- a/src/main/java/hello/exception/servlet/ErrorPageController.java
+++ b/src/main/java/hello/exception/servlet/ErrorPageController.java
@@ -1,0 +1,23 @@
+package hello.exception.servlet;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Slf4j
+@Controller
+public class ErrorPageController {
+
+    @RequestMapping("/error-page/404")
+    public String errorPage404(HttpServletRequest request, HttpServletResponse response) {
+        log.info("errorPage 404");
+        return "error-page/404";
+    }
+    @RequestMapping("/error-page/500")
+    public String errorPage500(HttpServletRequest request, HttpServletResponse response) {
+        log.info("errorPage 500");
+        return "error-page/500";
+    }
+}

--- a/src/main/resources/templates/error-page/404.html
+++ b/src/main/resources/templates/error-page/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2>404 오류 화면</h2>
+    </div>
+    <div>
+    </div>
+    <p>오류 화면 입니다.</p>
+    <hr class="my-4">
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/error-page/500.html
+++ b/src/main/resources/templates/error-page/500.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2>500 오류 화면</h2>
+    </div>
+    <div>
+    </div>
+    <p>오류 화면 입니다.</p>
+    <hr class="my-4">
+</div> <!-- /container -->
+</body>
+</html>


### PR DESCRIPTION
### 작업 내용
- WebServerCustomizer를 통해 404, 500, RuntimeException 예외 매핑
- ErrorPageController 구현으로 오류 페이지 요청 처리
- Thymeleaf 기반 404, 500 오류 페이지 뷰 추가

### 변경 이유
- WAS 기본 오류 페이지 대신 사용자 친화적인 오류 화면 제공을 위해 구현
