### PR TITLE
feat: 서블릿 오류 페이지 작동 원리 구현 및 로그 출력

### DIFF
--- a/src/main/java/hello/exception/servlet/ErrorPageController.java
+++ b/src/main/java/hello/exception/servlet/ErrorPageController.java
@@ -9,15 +9,35 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Slf4j
 @Controller
 public class ErrorPageController {
+    //RequestDispatcher 상수로 정의되어 있음
+    public static final String ERROR_EXCEPTION ="jakarta.servlet.error.exception";
+    public static final String ERROR_EXCEPTION_TYPE ="jakarta.servlet.error.exception_type";
+    public static final String ERROR_MESSAGE = "jakarta.servlet.error.message";
+    public static final String ERROR_REQUEST_URI = "jakarta.servlet.error.request_uri";
+    public static final String ERROR_SERVLET_NAME ="jakarta.servlet.error.servlet_name";
+    public static final String ERROR_STATUS_CODE ="jakarta.servlet.error.status_code";
 
     @RequestMapping("/error-page/404")
     public String errorPage404(HttpServletRequest request, HttpServletResponse response) {
         log.info("errorPage 404");
+        printErrorInfo(request);
         return "error-page/404";
     }
     @RequestMapping("/error-page/500")
     public String errorPage500(HttpServletRequest request, HttpServletResponse response) {
         log.info("errorPage 500");
+        printErrorInfo(request);
         return "error-page/500";
     }
+
+    private void printErrorInfo(HttpServletRequest request) {
+        log.info("ERROR_EXCEPTION : {}", request.getAttribute(ERROR_EXCEPTION));
+        log.info("ERROR_EXCEPTION_TYPE : {}", request.getAttribute(ERROR_EXCEPTION_TYPE));
+        log.info("ERROR_MESSAGE : {}", request.getAttribute(ERROR_MESSAGE));
+        log.info("ERROR_REQUEST_URI : {}", request.getAttribute(ERROR_REQUEST_URI));
+        log.info("ERROR_SERVLET_NAME : {}", request.getAttribute(ERROR_SERVLET_NAME));
+        log.info("ERROR_STATUS_CODE : {}", request.getAttribute(ERROR_STATUS_CODE));
+        log.info("dispatchType= {}", request.getDispatcherType());
+    }
 }
+


### PR DESCRIPTION
### 작업 내용
- 예외 발생 및 sendError 호출 시 오류 페이지 동작 흐름 정리
- WAS가 오류 페이지를 내부 요청으로 처리하는 과정 구현
- ErrorPageController에 request.attribute 로그 출력 기능 추가
- 오류 발생 시 상태 코드, 요청 URI, 예외 타입 등 정보 확인 가능하도록 구현

### 변경 이유
- 오류 페이지 동작 방식을 코드와 로그를 통해 확인하고 이해하기 위함
- 클라이언트 친화적인 오류 처리 및 디버깅 편의성 확보 목적
