### PR TITLE
feat: DispatcherType 기반 필터 동작 제어 추가

### DIFF
--- a/src/main/java/hello/exception/WebConfig.java
+++ b/src/main/java/hello/exception/WebConfig.java
@@ -1,0 +1,23 @@
+package hello.exception;
+
+import hello.exception.filter.LogFilter;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public FilterRegistrationBean logFilter() {
+        FilterRegistrationBean<Filter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+        filterFilterRegistrationBean.setFilter(new LogFilter());
+        filterFilterRegistrationBean.setOrder(1);
+        filterFilterRegistrationBean.addUrlPatterns("/*");
+        filterFilterRegistrationBean.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ERROR);
+        return filterFilterRegistrationBean;
+    }
+}

--- a/src/main/java/hello/exception/filter/LogFilter.java
+++ b/src/main/java/hello/exception/filter/LogFilter.java
@@ -1,0 +1,35 @@
+package hello.exception.filter;
+import lombok.extern.slf4j.Slf4j;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+public class LogFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        log.info("log filter init");
+    }
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String requestURI = httpRequest.getRequestURI();
+        String uuid = UUID.randomUUID().toString();
+        try {
+            log.info("REQUEST [{}][{}][{}]", uuid, request.getDispatcherType(),
+                    requestURI);
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            log.info("RESPONSE [{}][{}][{}]", uuid, request.getDispatcherType(),
+                    requestURI);
+        }
+    }
+    @Override
+    public void destroy() {
+        log.info("log filter destroy");
+    }
+}


### PR DESCRIPTION
### 작업 내용
- LogFilter에서 요청 URI와 함께 DispatcherType 로그 출력 추가
- WebConfig에 DispatcherType.REQUEST, ERROR 설정으로 필터 적용 범위 제어
- 오류 페이지 요청 시에도 필터 동작 확인 가능하도록 구현

### 변경 이유
- 정상 요청과 오류 페이지 요청을 구분하여 불필요한 필터 실행 방지
- DispatcherType을 활용한 서블릿 예외 처리 흐름 학습 및 적용
