### PR TITLE
feat: 인터셉터 중복 호출 제거

### DIFF
--- a/src/main/java/hello/exception/WebConfig.java
+++ b/src/main/java/hello/exception/WebConfig.java
@@ -1,17 +1,27 @@
 package hello.exception;
 
 import hello.exception.filter.LogFilter;
+import hello.exception.interceptor.LogInterceptor;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Bean
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LogInterceptor())
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "*.ico", "/error", "/error-page/**"); // 오류 페이지 경로
+    }
+
+//    @Bean
     public FilterRegistrationBean logFilter() {
         FilterRegistrationBean<Filter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
         filterFilterRegistrationBean.setFilter(new LogFilter());

--- a/src/main/java/hello/exception/interceptor/LogInterceptor.java
+++ b/src/main/java/hello/exception/interceptor/LogInterceptor.java
@@ -1,0 +1,38 @@
+package hello.exception.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+@Slf4j
+public class LogInterceptor implements HandlerInterceptor {
+    public static final String LOG_ID = "logId";
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse
+            response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+        String uuid = UUID.randomUUID().toString();
+        request.setAttribute(LOG_ID, uuid);
+        log.info("REQUEST [{}][{}][{}][{}]", uuid, request.getDispatcherType(),
+                requestURI, handler);
+        return true;
+    }
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse
+            response, Object handler, ModelAndView modelAndView) throws Exception {
+        log.info("postHandle [{}]", modelAndView);
+    }
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse
+            response, Object handler, Exception ex) throws Exception {
+        String requestURI = request.getRequestURI();
+        String logId = (String)request.getAttribute(LOG_ID);
+        log.info("RESPONSE [{}][{}][{}]", logId, request.getDispatcherType(), requestURI);
+        if (ex != null) {
+            log.error("afterCompletion error!!", ex);
+        }
+    }
+}


### PR DESCRIPTION
### 작업 내용
- LogInterceptor에 DispatcherType 로그 출력 기능 추가
- WebConfig 설정에서 /error-page/** 경로를 excludePathPatterns로 제외
- logFilter Bean 주석 처리하여 필터와 인터셉터의 중복 실행 방지

### 변경 이유
- 오류 페이지 내부 요청 시 인터셉터 중복 호출 문제 해결
- 정상 요청과 오류 요청의 처리 흐름을 명확히 구분하기 위함
