### PR TITLE
feat: 스프링 부트 기본 오류 페이지 적용

### DIFF
--- a/src/main/java/hello/exception/WebServerCustomizer.java
+++ b/src/main/java/hello/exception/WebServerCustomizer.java
@@ -6,7 +6,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-@Component
+//@Component
 public class WebServerCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
     @Override
     public void customize(ConfigurableWebServerFactory factory) {

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2>404 오류 화면 스프링 부트 제공</h2>
+    </div>
+    <div>
+    </div>
+    <p>오류 화면 입니다.</p>
+    <hr class="my-4">
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/error/4xx.html
+++ b/src/main/resources/templates/error/4xx.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2>4xx 오류 화면 스프링 부트 제공</h2>
+    </div>
+    <div>
+    </div>
+    <p>오류 화면 입니다.</p>
+    <hr class="my-4">
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<div class="container" style="max-width: 600px">
+    <div class="py-5 text-center">
+        <h2>500 오류 화면 스프링 부트 제공</h2>
+    </div>
+    <div>
+        <p>오류 화면 입니다.</p>
+    </div>
+    <hr class="my-4">
+</div> <!-- /container -->
+</body>
+</html>


### PR DESCRIPTION
### 작업 내용
- 스프링 부트 기본 제공 오류 처리 메커니즘 적용
- WebServerCustomizer 제거 후 /error 경로 자동 매핑 사용
- 뷰 템플릿 경로에 오류 페이지 추가
  - resources/templates/error/4xx.html
  - resources/templates/error/404.html
  - resources/templates/error/500.html

### 변경 이유
- 불필요한 커스터마이징 제거 및 스프링 부트 기본 기능 활용
- 오류 상태 코드별 사용자 친화적인 화면 제공
