### PR TITLE
feat: BasicErrorController 기반 오류 페이지 설정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 server.error.whitelabel.enabled=false
+server.error.include-exception=true
+server.error.include-message=on_param
+server.error.include-stacktrace=on_param
+server.error.include-binding-errors=on_param

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -11,6 +11,21 @@
     <div>
         <p>오류 화면 입니다.</p>
     </div>
+
+    <ul>
+        <li>오류 정보</li>
+        <ul>
+            <li th:text="|timestamp: ${timestamp}|"></li>
+            <li th:text="|path: ${path}|"></li>
+            <li th:text="|status: ${status}|"></li>
+            <li th:text="|message: ${message}|"></li>
+            <li th:text="|error: ${error}|"></li>
+            <li th:text="|exception: ${exception}|"></li>
+            <li th:text="|errors: ${errors}|"></li>
+            <li th:text="|trace: ${trace}|"></li>
+        </ul>
+        </li>
+    </ul>
     <hr class="my-4">
 </div> <!-- /container -->
 </body>


### PR DESCRIPTION
### 작업 내용
- BasicErrorController가 전달하는 오류 정보를 뷰 템플릿에서 출력할 수 있도록 구현
- 500 오류 페이지에 timestamp, status, path, message 등 오류 상세 정보 표시
- application.properties에서 오류 정보 노출 옵션 설정
  - exception, message, stacktrace, binding-errors 노출 여부 제어

### 변경 이유
- 스프링 부트 기본 오류 처리 흐름 이해 및 적용
- 디버깅 시 필요한 오류 정보를 확인할 수 있도록 설정 추가
- 운영 환경에서는 불필요한 내부 정보 노출을 방지하기 위함
