### PR TITLE
feat: API 예외 처리 기능 추가

### DIFF
--- a/src/main/java/hello/exception/WebServerCustomizer.java
+++ b/src/main/java/hello/exception/WebServerCustomizer.java
@@ -6,7 +6,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-//@Component
+@Component
 public class WebServerCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
     @Override
     public void customize(ConfigurableWebServerFactory factory) {

--- a/src/main/java/hello/exception/api/ApiExceptionController.java
+++ b/src/main/java/hello/exception/api/ApiExceptionController.java
@@ -1,0 +1,29 @@
+package hello.exception.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class ApiExceptionController {
+    @GetMapping("/api/members/{id}")
+    public MemberDto getMember(@PathVariable("id") String id) {
+
+        if (id.equals("ex")) {
+            throw new RuntimeException("잘못된 사용자");
+        }
+        return new MemberDto(id, "hello " + id);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class MemberDto{
+        private String memberId;
+        private String name;
+    }
+
+}

--- a/src/main/java/hello/exception/servlet/ErrorPageController.java
+++ b/src/main/java/hello/exception/servlet/ErrorPageController.java
@@ -1,10 +1,17 @@
 package hello.exception.servlet;
 
+import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Controller
@@ -29,6 +36,22 @@ public class ErrorPageController {
         printErrorInfo(request);
         return "error-page/500";
     }
+
+    @RequestMapping(value = "/error-page/500", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> errorPage500Api(
+            HttpServletRequest request, HttpServletResponse response) {
+
+        log.info("API errorPage 500");
+
+        Map<String, Object> result = new HashMap<>();
+        Exception ex = (Exception) request.getAttribute(ERROR_EXCEPTION);
+        result.put("status", request.getAttribute(ERROR_STATUS_CODE));
+        result.put("message", ex.getMessage());
+
+        Integer statusCode = (Integer) request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        return new ResponseEntity<>(result, HttpStatus.valueOf(statusCode));
+    }
+
 
     private void printErrorInfo(HttpServletRequest request) {
         log.info("ERROR_EXCEPTION : {}", request.getAttribute(ERROR_EXCEPTION));


### PR DESCRIPTION
### 변경 내용
- WebServerCustomizer 등록으로 404, 500, RuntimeException 발생 시 오류 페이지 매핑
- ApiExceptionController 추가: 회원 조회 API 및 테스트 예외 발생 코드 구현
- ErrorPageController 수정: 오류 발생 시 JSON 형태 응답 처리 (`status`, `message`)
- Postman을 통해 정상 호출 및 예외 발생 호출 테스트 진행

### 테스트 방법
1. 정상 요청
   - `GET /api/members/spring`
   - JSON 응답 반환 확인
2. 예외 요청
   - `GET /api/members/ex`
   - `Accept: application/json` 헤더 설정 시 JSON 오류 응답 반환
   - 그 외의 경우 기존 HTML 오류 페이지 응답 확인

### 참고 사항
- API 클라이언트는 오류 발생 시에도 JSON 응답을 받을 수 있도록 처리
