### PR TITLE
feat: HandlerExceptionResolver 적용으로 API 예외 처리 확장

### DIFF
--- a/src/main/java/hello/exception/WebConfig.java
+++ b/src/main/java/hello/exception/WebConfig.java
@@ -2,13 +2,17 @@ package hello.exception;
 
 import hello.exception.filter.LogFilter;
 import hello.exception.interceptor.LogInterceptor;
+import hello.exception.resolver.MyHandlerExceptionResolver;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -21,7 +25,12 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/css/**", "*.ico", "/error", "/error-page/**"); // 오류 페이지 경로
     }
 
-//    @Bean
+    @Override
+    public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> resolvers) {
+        resolvers.add(new MyHandlerExceptionResolver());
+    }
+
+    //    @Bean
     public FilterRegistrationBean logFilter() {
         FilterRegistrationBean<Filter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
         filterFilterRegistrationBean.setFilter(new LogFilter());

--- a/src/main/java/hello/exception/WebServerCustomizer.java
+++ b/src/main/java/hello/exception/WebServerCustomizer.java
@@ -6,7 +6,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-@Component
+//@Component
 public class WebServerCustomizer implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
     @Override
     public void customize(ConfigurableWebServerFactory factory) {

--- a/src/main/java/hello/exception/api/ApiExceptionController.java
+++ b/src/main/java/hello/exception/api/ApiExceptionController.java
@@ -16,6 +16,10 @@ public class ApiExceptionController {
         if (id.equals("ex")) {
             throw new RuntimeException("잘못된 사용자");
         }
+
+        if (id.equals("bad")) {
+            throw new IllegalArgumentException("잘못된 입력 값");
+        }
         return new MemberDto(id, "hello " + id);
     }
 

--- a/src/main/java/hello/exception/resolver/MyHandlerExceptionResolver.java
+++ b/src/main/java/hello/exception/resolver/MyHandlerExceptionResolver.java
@@ -1,0 +1,27 @@
+package hello.exception.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.io.IOException;
+
+@Slf4j
+public class MyHandlerExceptionResolver implements HandlerExceptionResolver {
+    @Override
+    public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+
+        if (ex instanceof IllegalArgumentException) {
+            log.info("IllegalArgumentException resolver to 400");
+            try {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+                return new ModelAndView();
+            } catch (IOException e) {
+                log.error("resolver ex", e);
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### 변경 내용
- ApiExceptionController 수정
  - id 값이 `bad`일 경우 IllegalArgumentException 발생하도록 추가
- MyHandlerExceptionResolver 구현
  - IllegalArgumentException 발생 시 HTTP 400 상태 코드 반환
  - 빈 ModelAndView 반환으로 뷰 렌더링 없이 정상 흐름 종료
- WebConfig 수정
  - extendHandlerExceptionResolvers() 사용하여 커스텀 Resolver 등록
- Postman 테스트 검증
  - `/api/members/ex` → HTTP 500
  - `/api/members/bad` → HTTP 400

### 테스트 방법
1. `GET /api/members/ex`
   - RuntimeException 발생
   - HTTP 상태 코드 500 응답 확인
2. `GET /api/members/bad`
   - IllegalArgumentException 발생
   - HTTP 상태 코드 400 응답 확인

