### PR TITLE
feat: UserException 및 UserHandlerExceptionResolver 추가

### DIFF
--- a/src/main/java/hello/exception/WebConfig.java
+++ b/src/main/java/hello/exception/WebConfig.java
@@ -3,6 +3,7 @@ package hello.exception;
 import hello.exception.filter.LogFilter;
 import hello.exception.interceptor.LogInterceptor;
 import hello.exception.resolver.MyHandlerExceptionResolver;
+import hello.exception.resolver.UserHandlerExceptionResolver;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -28,6 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void extendHandlerExceptionResolvers(List<HandlerExceptionResolver> resolvers) {
         resolvers.add(new MyHandlerExceptionResolver());
+        resolvers.add(new UserHandlerExceptionResolver());
     }
 
     //    @Bean

--- a/src/main/java/hello/exception/api/ApiExceptionController.java
+++ b/src/main/java/hello/exception/api/ApiExceptionController.java
@@ -1,5 +1,6 @@
 package hello.exception.api;
 
+import hello.exception.exception.UserException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,9 @@ public class ApiExceptionController {
 
         if (id.equals("bad")) {
             throw new IllegalArgumentException("잘못된 입력 값");
+        }
+        if (id.equals("user-ex")) {
+            throw new UserException("사용자 오류");
         }
         return new MemberDto(id, "hello " + id);
     }

--- a/src/main/java/hello/exception/exception/UserException.java
+++ b/src/main/java/hello/exception/exception/UserException.java
@@ -1,0 +1,20 @@
+package hello.exception.exception;
+
+public class UserException extends RuntimeException {
+    public UserException() {
+        super();
+    }
+    public UserException(String message) {
+        super(message);
+    }
+    public UserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public UserException(Throwable cause) {
+        super(cause);
+    }
+    protected UserException(String message, Throwable cause, boolean
+            enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/hello/exception/resolver/UserHandlerExceptionResolver.java
+++ b/src/main/java/hello/exception/resolver/UserHandlerExceptionResolver.java
@@ -1,0 +1,48 @@
+package hello.exception.resolver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hello.exception.exception.UserException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class UserHandlerExceptionResolver implements HandlerExceptionResolver {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Override
+    public ModelAndView resolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        try {
+            if (ex instanceof UserException) {
+                log.info("UserException resolver to 400");
+                String acceptHeader = request.getHeader("accept");
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+
+                if ("application/json".equals(acceptHeader)) {
+                    Map<String, Object> errorResult = new HashMap<>();
+                    errorResult.put("ex", ex.getClass());
+                    errorResult.put("meesaage", ex.getMessage());
+
+                    String result = objectMapper.writeValueAsString(errorResult);
+
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("utf-8");
+                    response.getWriter().write(result);
+                    return new ModelAndView();
+                } else{
+                    // TEXT/HTML
+                    return new ModelAndView("error/500");
+                }
+            }
+        } catch (IOException e) {
+            log.error("resolver ex', e");
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### 변경 내용
- UserException 추가
  - RuntimeException을 상속하는 사용자 정의 예외 클래스 구현
- ApiExceptionController 수정
  - id 값이 `user-ex`일 경우 UserException 발생하도록 코드 추가
- UserHandlerExceptionResolver 구현
  - UserException 처리 전용 Resolver 추가
  - 상태 코드 400 반환
  - Accept 헤더가 `application/json`일 경우 JSON 응답 반환
  - 그 외 경우 HTML 오류 페이지(error/400) 렌더링
- WebConfig 수정
  - MyHandlerExceptionResolver, UserHandlerExceptionResolver 함께 등록

### 테스트 방법
1. `GET /api/members/user-ex`
   - 헤더 `Accept: application/json`
     ```json
     {
       "ex": "hello.exception.exception.UserException",
       "message": "사용자 오류"
     }
     ```
   - 헤더 `Accept: text/html`
     ```html
     <!DOCTYPE HTML>
     <html>...</html>
     ```

### 참고 사항
- ExceptionResolver에서 예외를 처리하므로 서블릿 컨테이너까지 예외가 전달되지 않음
- WAS 입장에서는 정상 응답으로 처리되어 추가적인 `/error` 호출 과정 생략
