### PR TITLE
feat: DefaultHandlerExceptionResolver 예외 처리 적용

### DIFF
--- a/src/main/java/hello/exception/api/ApiExceptionController.java
+++ b/src/main/java/hello/exception/api/ApiExceptionController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -40,6 +41,10 @@ public class ApiExceptionController {
         throw new ResponseStatusException(HttpStatus.NOT_FOUND, "error.bad", new IllegalArgumentException());
     }
 
+    @GetMapping("/api/default-handler-ex")
+    public String defaultException(@RequestParam Integer data) {
+        return "ok";
+    }
 
     @Data
     @AllArgsConstructor


### PR DESCRIPTION
### 변경 내용
- ApiExceptionController에 `/api/default-handler-ex` 엔드포인트 추가
  - @RequestParam Integer data 파라미터 선언
  - 문자열 입력 시 MethodArgumentTypeMismatchException 발생
- DefaultHandlerExceptionResolver 적용
  - 내부적으로 sendError(400) 호출
  - 500 오류 대신 400 Bad Request 응답 반환

### 테스트 방법
1. `GET /api/default-handler-ex?data=10`
   - 정상 응답: "ok"
2. `GET /api/default-handler-ex?data=hello`
   - MethodArgumentTypeMismatchException 발생
   - HTTP 400 Bad Request 반환

### 참고 사항
- DefaultHandlerExceptionResolver는 스프링 내부 예외를 처리하여 올바른 HTTP 상태 코드로 변환
- API 응답을 JSON 형태로 제어하기는 한계가 있어, 이후 ExceptionHandlerExceptionResolver(@ExceptionHandler) 활용 예정
