### PR TITLE
refactor: 예외 처리 로직을 @ControllerAdvice로 분리

### DIFF
--- a/src/main/java/hello/exception/api/ApiExceptionV3Controller.java
+++ b/src/main/java/hello/exception/api/ApiExceptionV3Controller.java
@@ -2,22 +2,21 @@ package hello.exception.api;
 
 import hello.exception.ExceptionApplication;
 import hello.exception.exception.UserException;
-import hello.exception.exhandler.ErrorResult;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-public class ApiExceptionV2Controller {
+public class ApiExceptionV3Controller {
 
-    public ApiExceptionV2Controller(ExceptionApplication exceptionApplication) {
+    public ApiExceptionV3Controller(ExceptionApplication exceptionApplication) {
     }
 
-    @GetMapping("/api2/members/{id}")
+    @GetMapping("/api3/members/{id}")
     public MemberDto getMember(@PathVariable("id") String id) {
 
         if (id.equals("ex")) {

--- a/src/main/java/hello/exception/exhandler/advice/ExControllerAdvice.java
+++ b/src/main/java/hello/exception/exhandler/advice/ExControllerAdvice.java
@@ -1,0 +1,35 @@
+package hello.exception.exhandler.advice;
+
+import hello.exception.exception.UserException;
+import hello.exception.exhandler.ErrorResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "hello.exception.api")
+public class ExControllerAdvice {
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ErrorResult illegalExHandler(IllegalArgumentException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult("BAD", e.getMessage());
+    }
+
+    @ExceptionHandler()
+    public ResponseEntity<ErrorResult> userExHandler(UserException e) {
+        log.error("[exceptionHandler] ex", e);
+        ErrorResult errorResult = new ErrorResult("USER-EX", e.getMessage());
+        return new ResponseEntity(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler
+    public ErrorResult exHandler(Exception e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult("EX", "내부 오류");
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 기존 ApiExceptionV2Controller 내부의 예외 처리 코드를 제거하고, 전역 예외 처리 클래스로 분리
- @RestControllerAdvice를 적용한 ExControllerAdvice를 추가하여 공통 예외 처리 관리
- IllegalArgumentException, UserException, Exception 각각에 대한 처리 로직 구현

### 주요 변경 사항
- ApiExceptionV2Controller: 예외 처리 메서드 삭제
- ExControllerAdvice: 전역 예외 처리 담당 클래스 추가

### 테스트 방법
- /api2/members/bad 호출 시 400 에러 JSON 응답 확인
- /api2/members/user-ex 호출 시 400 에러 JSON 응답 확인
- /api2/members/ex 호출 시 500 에러 JSON 응답 확인
